### PR TITLE
12 get api articles article id comment count

### DIFF
--- a/__tests__/articles.test.js
+++ b/__tests__/articles.test.js
@@ -23,9 +23,18 @@ describe("GET /api/articles/article_id", () => {
                 expect(articles.votes).toBe(0);
                 expect(articles.article_img_url).toBe(
                     "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
-                );
+                )
+                expect(articles.comment_count).toBe(0);
             });
     });
+    test("200: Responds with the article id with the correct comment count", () => {
+        return request(app)
+            .get("/api/articles/1")
+            .expect(200)
+            .then(({body: {articles}}) => {
+                expect(articles.comment_count).toBe(11)
+            })
+    })
 });
 
 describe("GET /api/articles/article_id/comments", () => {

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -5,9 +5,11 @@ const { checkExists, commentCountLookup } = require("../db/seeds/utils");
 exports.fetchArticlesById = (article_id) => {
     const promises = [
         db.query(`SELECT * FROM articles where article_id = $1`, [article_id]),
+        commentCountLookup(),
         checkExists("articles", "article_id", article_id),
     ];
-    return Promise.all(promises).then(([{ rows }]) => {
+    return Promise.all(promises).then(([{ rows }, comment_count]) => {
+        rows[0].comment_count = comment_count[article_id]
         return rows[0];
     });
 };


### PR DESCRIPTION
As per task 12, this will add comment_count to GET /api/articles/:article_id alongside modifying the testing to account for this.